### PR TITLE
Refactor managedcluster controller

### DIFF
--- a/controllers/managedcluster_controller_test.go
+++ b/controllers/managedcluster_controller_test.go
@@ -3,117 +3,267 @@
 package controllers
 
 import (
-	"context"
-	"time"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"reflect"
+	"testing"
 
 	discoveryv1 "github.com/open-cluster-management/discovery/api/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
-	ref "k8s.io/client-go/tools/reference"
 )
 
-var _ = Describe("ManagedCluster controller", func() {
-	// Define utility constants for object names and testing timeouts/durations and intervals.
-	const (
-		Namespace  = "managed"
-		SecretName = "test-connection-secret"
-
-		timeout  = time.Second * 4
-		duration = time.Second * 10
-		interval = time.Millisecond * 250
-	)
-
-	Context("When creating a ManagedCluster", func() {
-		It("Should update the corresponding discovered cluster to indicate managed status", func() {
-			ctx := context.Background()
-
-			By("Creating a namespace to work in")
-			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: Namespace}}
-			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
-
-			secretKey := types.NamespacedName{
-				Namespace: Namespace,
-				Name:      SecretName,
-			}
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretKey.Name,
-					Namespace: secretKey.Namespace,
-				},
-				StringData: map[string]string{
-					"metadata": "ocmAPIToken: dummytoken",
-				},
-			}
-			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
-
-			createdSecret := corev1.Secret{}
-			Eventually(func() error {
-				return k8sClient.Get(ctx, secretKey, &createdSecret)
-			}, timeout, interval).Should(Succeed())
-
-			By("By manually creating an unmanaged DiscoveredCluster")
-			key := types.NamespacedName{
-				Namespace: Namespace,
-				Name:      "discoveredcluster1",
-			}
-			dc1 := &discoveryv1.DiscoveredCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      key.Name,
-					Namespace: key.Namespace,
-				},
-				Spec: discoveryv1.DiscoveredClusterSpec{
-					Name: "cluster-id-1",
-				},
-			}
-
-			secretRef, err := ref.GetReference(k8sClient.Scheme(), &createdSecret)
-			Expect(err).NotTo(HaveOccurred())
-			dc1.Spec.ProviderConnections = append(dc1.Spec.ProviderConnections, *secretRef)
-
-			Expect(k8sClient.Create(ctx, dc1)).To(Succeed())
-
-			By("By creating a new ManagedCluster")
-			mc1 := &unstructured.Unstructured{
+func Test_getClusterID(t *testing.T) {
+	tests := []struct {
+		name           string
+		managedCluster unstructured.Unstructured
+		want           string
+	}{
+		{
+			name: "Managed cluster without labels populated",
+			managedCluster: unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "cluster.open-cluster-management.io/v1",
 					"kind":       "ManagedCluster",
 					"metadata": map[string]interface{}{
 						"name":      "managedcluster1",
-						"namespace": Namespace,
-						"labels": map[string]string{
-							"clusterID": "cluster-id-1",
-						},
+						"namespace": "test",
 					},
 				},
+			},
+			want: "",
+		},
+		{
+			name: "Managed cluster with labels populated",
+			managedCluster: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "cluster.open-cluster-management.io/v1",
+					"kind":       "ManagedCluster",
+					"metadata": map[string]interface{}{
+						"name":      "managedcluster1",
+						"namespace": "test",
+						"labels":    map[string]interface{}{"clusterID": "cluster-id-1"},
+					},
+				},
+			},
+			want: "cluster-id-1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getClusterID(tt.managedCluster); got != tt.want {
+				t.Errorf("getClusterID() = %v, want %v", got, tt.want)
 			}
-			Expect(k8sClient.Create(ctx, mc1)).To(Succeed())
-
-			By("Checking the DiscoveredCluster is now labeled as managed")
-			var fetchedDiscoveredCluster discoveryv1.DiscoveredCluster
-			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, key, &fetchedDiscoveredCluster); err != nil {
-					return false
-				}
-				return fetchedDiscoveredCluster.Spec.IsManagedCluster
-			}, timeout, interval).Should(BeTrue())
-
-			By("By deleting the ManagedCluster")
-			Expect(k8sClient.Delete(ctx, mc1)).To(Succeed())
-
-			By("Checking the DiscoveredCluster is now labeled as unmanaged")
-			Expect(k8sClient.Get(ctx, key, &fetchedDiscoveredCluster)).To(Succeed())
-			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, key, &fetchedDiscoveredCluster); err != nil {
-					return true
-				}
-				return fetchedDiscoveredCluster.Spec.IsManagedCluster
-			}, timeout, interval).Should(BeFalse())
-
 		})
-	})
-})
+	}
+}
+
+func Test_matchingDiscoveredCluster(t *testing.T) {
+	a := discoveryv1.DiscoveredCluster{
+		Spec: discoveryv1.DiscoveredClusterSpec{
+			Name: "dc1",
+		},
+	}
+	b := discoveryv1.DiscoveredCluster{
+		Spec: discoveryv1.DiscoveredClusterSpec{
+			Name: "dc2",
+		},
+	}
+
+	type args struct {
+		discoveredList *discoveryv1.DiscoveredClusterList
+		id             string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *discoveryv1.DiscoveredCluster
+	}{
+		{
+			name: "Matching cluster",
+			args: args{
+				discoveredList: &discoveryv1.DiscoveredClusterList{
+					Items: []discoveryv1.DiscoveredCluster{a, b},
+				},
+				id: "dc1",
+			},
+			want: &a,
+		},
+		{
+			name: "No matching cluster",
+			args: args{
+				discoveredList: &discoveryv1.DiscoveredClusterList{
+					Items: []discoveryv1.DiscoveredCluster{a, b},
+				},
+				id: "dc0",
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchingDiscoveredCluster(tt.args.discoveredList, tt.args.id); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("matchingDiscoveredCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_setManagedStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		dc   *discoveryv1.DiscoveredCluster
+		want bool
+	}{
+		{
+			name: "Managed labels set",
+			dc: &discoveryv1.DiscoveredCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a",
+					Namespace: "b",
+					Labels:    map[string]string{"isManagedCluster": "true"},
+				},
+				Spec: discoveryv1.DiscoveredClusterSpec{
+					IsManagedCluster: true,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Managed label missing",
+			dc: &discoveryv1.DiscoveredCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a",
+					Namespace: "b",
+					Labels:    map[string]string{"isManagedCluster": "false"},
+				},
+				Spec: discoveryv1.DiscoveredClusterSpec{
+					IsManagedCluster: false,
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := setManagedStatus(tt.dc); got != tt.want {
+				t.Errorf("setManagedStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_unsetManagedStatus(t *testing.T) {
+	type args struct {
+		dc *discoveryv1.DiscoveredCluster
+	}
+	tests := []struct {
+		name string
+		dc   *discoveryv1.DiscoveredCluster
+		want bool
+	}{
+		{
+			name: "Managed labels set",
+			dc: &discoveryv1.DiscoveredCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a",
+					Namespace: "b",
+					Labels:    map[string]string{"isManagedCluster": "true"},
+				},
+				Spec: discoveryv1.DiscoveredClusterSpec{
+					IsManagedCluster: true,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Managed label missing",
+			dc: &discoveryv1.DiscoveredCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a",
+					Namespace: "b",
+					Labels:    map[string]string{"isManagedCluster": "false"},
+				},
+				Spec: discoveryv1.DiscoveredClusterSpec{
+					IsManagedCluster: false,
+				},
+			},
+			want: false,
+		}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unsetManagedStatus(tt.dc); got != tt.want {
+				t.Errorf("unsetManagedStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isManagedCluster(t *testing.T) {
+	managedClusters := unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"apiVersion": "cluster.open-cluster-management.io/v1",
+					"kind":       "ManagedCluster",
+					"metadata": map[string]interface{}{
+						"name":      "managedcluster1",
+						"namespace": "test",
+						"labels":    map[string]interface{}{"clusterID": "cluster-id-1"},
+					},
+				},
+			},
+			{
+				Object: map[string]interface{}{
+					"apiVersion": "cluster.open-cluster-management.io/v1",
+					"kind":       "ManagedCluster",
+					"metadata": map[string]interface{}{
+						"name":      "managedcluster2",
+						"namespace": "test",
+						"labels":    map[string]interface{}{"clusterID": "cluster-id-2"},
+					},
+				},
+			},
+		},
+	}
+
+	type args struct {
+		dc              discoveryv1.DiscoveredCluster
+		managedClusters *unstructured.UnstructuredList
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Cluster is managed",
+			args: args{
+				dc: discoveryv1.DiscoveredCluster{
+					Spec: discoveryv1.DiscoveredClusterSpec{
+						Name: "cluster-id-1",
+					},
+				},
+				managedClusters: &managedClusters,
+			},
+			want: true,
+		},
+		{
+			name: "Cluster is not managed",
+			args: args{
+				dc: discoveryv1.DiscoveredCluster{
+					Spec: discoveryv1.DiscoveredClusterSpec{
+						Name: "cluster-id-0",
+					},
+				},
+				managedClusters: &managedClusters,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isManagedCluster(tt.args.dc, tt.args.managedClusters); got != tt.want {
+				t.Errorf("isManagedCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refactor ManagedCluster controller to move logic out of reconcile function and into separate functions. Replace functional tests with unit tests.