### PR TITLE
Fix bug in assignManagedStatus

### DIFF
--- a/controllers/discoveryconfig_controller.go
+++ b/controllers/discoveryconfig_controller.go
@@ -218,9 +218,10 @@ func assignManagedStatus(discovered map[string]discoveryv1.DiscoveredCluster, ma
 		id := getClusterID(mc)
 		if id != "" {
 			// Update cluster as managed
-			dc := discovered[id]
-			setManagedStatus(&dc)
-			discovered[id] = dc
+			if dc, ok := discovered[id]; ok {
+				setManagedStatus(&dc)
+				discovered[id] = dc
+			}
 		}
 	}
 }

--- a/controllers/discoveryconfig_controller_test.go
+++ b/controllers/discoveryconfig_controller_test.go
@@ -121,6 +121,16 @@ func Test_assignManagedStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "cluster.open-cluster-management.io/v1",
+				"kind":       "ManagedCluster",
+				"metadata": map[string]interface{}{
+					"name":   "d",
+					"labels": map[string]interface{}{"clusterID": "d"},
+				},
+			},
+		},
 	}
 
 	assignManagedStatus(discovered, managed)
@@ -143,7 +153,12 @@ func Test_assignManagedStatus(t *testing.T) {
 		dc := discovered["c"]
 		managedLabel := dc.GetLabels()["isManagedCluster"]
 		if dc.Spec.IsManagedCluster || managedLabel == "true" {
-			t.Errorf("Expected cluster %s to be labeled as managed: %+v", dc.Name, dc)
+			t.Errorf("Expected cluster %s to not be labeled as managed: %+v", dc.Name, dc)
+		}
+	})
+	t.Run("Discovered list not added to", func(t *testing.T) {
+		if len(discovered) != 3 {
+			t.Errorf("The discoveredlist should not change in size. Wanted: %d. Got: %d.", 3, len(discovered))
 		}
 	})
 }


### PR DESCRIPTION
Resolves https://github.com/open-cluster-management/backlog/issues/11716

Added a failing unit test to check that the list of DiscoveredClusters is not modified, then got it passing by updating the method with a check. Also included an undiscovered managedcluster in the functional tests.