### PR TITLE
Default name of discoveryconfig to be discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,11 +190,11 @@ logs:
 
 # Annotate discoveryconfig to target mock server
 annotate:
-	kubectl annotate discoveryconfig discoveryconfig ocmBaseURL=http://mock-ocm-server.$(NAMESPACE).svc.cluster.local:3000 --overwrite
+	kubectl annotate discoveryconfig discovery ocmBaseURL=http://mock-ocm-server.$(NAMESPACE).svc.cluster.local:3000 --overwrite
 
 # Remove mock server annotation
 unannotate:
-	kubectl annotate discoveryconfig discoveryconfig ocmBaseURL-
+	kubectl annotate discoveryconfig discovery ocmBaseURL-
 
 set-copyright:
 	@bash ./cicd-scripts/set-copyright.sh

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This will create a `DiscoveryConfig` like the example below:
 apiVersion: discovery.open-cluster-management.io/v1
 kind: DiscoveryConfig
 metadata:
-  name: discoveryconfig
+  name: discovery
 spec:
   providerConnections:
     - ocm-api-token

--- a/bundle/manifests/discovery.clusterserviceversion.yaml
+++ b/bundle/manifests/discovery.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
           "apiVersion": "discovery.open-cluster-management.io/v1",
           "kind": "DiscoveryConfig",
           "metadata": {
-            "name": "discoveryconfig"
+            "name": "discovery"
           },
           "spec": {
             "credential": "ocm-api-token",

--- a/config/samples/discovery_v1_discoveryconfig.yaml
+++ b/config/samples/discovery_v1_discoveryconfig.yaml
@@ -3,7 +3,7 @@
 apiVersion: discovery.open-cluster-management.io/v1
 kind: DiscoveryConfig
 metadata:
-  name: discoveryconfig
+  name: discovery
 spec:
   credential: ocm-api-token
   filters:

--- a/controllers/discoveryconfig_controller.go
+++ b/controllers/discoveryconfig_controller.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	defaultDiscoveryConfigName = "discoveryconfig"
+	defaultDiscoveryConfigName = "discovery"
 )
 
 var (

--- a/test/e2e/discoveryconfig_controller.go
+++ b/test/e2e/discoveryconfig_controller.go
@@ -23,7 +23,7 @@ import (
 
 // Define utility constants for object names and testing timeouts/durations and intervals.
 const (
-	DiscoveryConfigName = "discoveryconfig"
+	DiscoveryConfigName = "discovery"
 	SecretName          = "test-connection-secret"
 	TestserverName      = "mock-ocm-server"
 

--- a/testserver/Makefile
+++ b/testserver/Makefile
@@ -27,7 +27,7 @@ server/docker-run:
 
 ## Annotate DiscoveryConfig with Mock OCM Server URL
 server/annotate:
-	oc annotate discoveryconfig discoveryconfig ocmBaseURL=http://mock-ocm-server.open-cluster-management.svc.cluster.local:3000 --overwrite
+	oc annotate discoveryconfig discovery ocmBaseURL=http://mock-ocm-server.open-cluster-management.svc.cluster.local:3000 --overwrite
 
 DUMMY_ENCRYPTION = $(shell echo "ocmAPIToken: dummytoken" | base64)
 server/secret:


### PR DESCRIPTION
Allows for default name of discoveryconfig resource to be `discovery` to match with what UI creates