### PR TITLE
Update DiscoveredClusterSpec comparison check

### DIFF
--- a/api/v1alpha1/discoveredcluster_types.go
+++ b/api/v1alpha1/discoveredcluster_types.go
@@ -19,6 +19,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -68,4 +70,22 @@ type DiscoveredClusterList struct {
 
 func init() {
 	SchemeBuilder.Register(&DiscoveredCluster{}, &DiscoveredClusterList{})
+}
+
+// Equal reports whether the spec of a is equal to b.
+func (a DiscoveredCluster) Equal(b DiscoveredCluster) bool {
+	if a.Spec.Name != b.Spec.Name ||
+		a.Spec.DisplayName != b.Spec.DisplayName ||
+		a.Spec.Console != b.Spec.Console ||
+		a.Spec.APIURL != b.Spec.APIURL ||
+		a.Spec.CreationTimestamp.Truncate(time.Second) != b.Spec.CreationTimestamp.Truncate(time.Second) ||
+		a.Spec.ActivityTimestamp.Truncate(time.Second) != b.Spec.ActivityTimestamp.Truncate(time.Second) ||
+		a.Spec.OpenshiftVersion != b.Spec.OpenshiftVersion ||
+		a.Spec.CloudProvider != b.Spec.CloudProvider ||
+		a.Spec.Status != b.Spec.Status ||
+		a.Spec.IsManagedCluster != b.Spec.IsManagedCluster ||
+		a.Spec.Credential != b.Spec.Credential {
+		return false
+	}
+	return true
 }

--- a/controllers/discoveryconfig_controller.go
+++ b/controllers/discoveryconfig_controller.go
@@ -274,7 +274,7 @@ func (r *DiscoveryConfigReconciler) applyCluster(ctx context.Context, config *di
 		return r.createCluster(ctx, config, dc)
 	}
 
-	if same(dc, current) {
+	if dc.Equal(current) {
 		// Discovered cluster has not changed
 		return nil
 	}
@@ -329,30 +329,4 @@ func getURLOverride(config *discovery.DiscoveryConfig) string {
 		return annotations[baseURLAnnotation]
 	}
 	return ""
-}
-
-func same(c1, c2 discovery.DiscoveredCluster) bool {
-	c1i, c2i := c1.Spec, c2.Spec
-	if c1i.CloudProvider != c2i.CloudProvider {
-		return false
-	}
-	if c1i.Console != c2i.Console {
-		return false
-	}
-	if c1i.Name != c2i.Name {
-		return false
-	}
-	if c1i.DisplayName != c2i.DisplayName {
-		return false
-	}
-	if c1i.OpenshiftVersion != c2i.OpenshiftVersion {
-		return false
-	}
-	if c1i.IsManagedCluster != c2i.IsManagedCluster {
-		return false
-	}
-	if c1i.Credential != c2i.Credential {
-		return false
-	}
-	return true
 }

--- a/controllers/discoveryconfig_controller_test.go
+++ b/controllers/discoveryconfig_controller_test.go
@@ -163,60 +163,6 @@ func Test_assignManagedStatus(t *testing.T) {
 	})
 }
 
-func Test_same(t *testing.T) {
-	cluster1 := discovery.DiscoveredCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "c1",
-			Namespace: "test",
-			Labels:    map[string]string{"isManagedCluster": "false"},
-		},
-		Spec: discovery.DiscoveredClusterSpec{
-			Name:          "c1",
-			CloudProvider: "aws",
-			Status:        "Active",
-		},
-	}
-	cluster2 := discovery.DiscoveredCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "c2",
-			Namespace: "test",
-			Labels:    map[string]string{"isManagedCluster": "false"},
-		},
-		Spec: discovery.DiscoveredClusterSpec{
-			Name:          "c2",
-			CloudProvider: "aws",
-			Status:        "Active",
-		},
-	}
-
-	tests := []struct {
-		name string
-		c1   discovery.DiscoveredCluster
-		c2   discovery.DiscoveredCluster
-		want bool
-	}{
-		{
-			name: "Equivalent clusters",
-			c1:   cluster1,
-			c2:   cluster1,
-			want: true,
-		},
-		{
-			name: "Different clusters",
-			c1:   cluster1,
-			c2:   cluster2,
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := same(tt.c1, tt.c2); got != tt.want {
-				t.Errorf("same() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_getURLOverride(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Prior to this, some fields like `ActivityTimestamp` were ignored for updates