### PR TITLE
Organize Makefile and document running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ After your PR is ready to commit, please run following commands to check your co
 ```shell
 make manifests              ## Regenerate manifests if necessary
 make test                   ## Run unit tests
-make integration-tests      ## Run functional tests
+make deploy-and-test        ## Run functional tests
                         OR
 make verify                 ## Runs all of the above commands
 ```
@@ -72,3 +72,45 @@ make docker-build           ## Ensure build succeeds
 ```
 
 Now, you can follow the [README](./README.md) to work with the open-cluster-management/discovery API repository.
+
+## Running tests
+
+The functional tests use a test server to mock OCM responses. Before running the tests both the discovery-operator
+and the mock-ocm-server must be running against a cluster.
+
+### Outside the cluster
+
+Follow the instructions for installing the operator outside the cluster. Then, in a separate terminal, run the testserver.
+
+```shell
+make server-run
+```
+
+With both components running, initiate the tests with the following command:
+
+```shell
+make integration-tests-local
+```
+
+### Inside the cluster
+
+Follow the instructions for installing the operator inside the cluster. Then do the same for the test server.
+
+1. Build the image:
+    ```shell
+    make server-docker-build SERVER_URL=<registry>/<imagename>:<tag>
+    ```
+2. Push the image:
+    ```shell
+    make server-docker-push SERVER_URL=<registry>/<imagename>:<tag>
+    ```
+3. Deploy the server:
+    ```shell
+    make server-deploy SERVER_URL=<registry>/<imagename>:<tag>
+    ```
+
+With both deployments running in the same namespace, initiate the tests with the following command:
+
+```shell
+make integration-tests
+```

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,6 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
--include testserver/Makefile
-
 all: build
 
 ##@ General
@@ -88,21 +86,15 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet `go list ./... | grep -v test`
 
-test: manifests generate fmt vet ## Run tests.
-	go test `go list ./... | grep -v e2e` -coverprofile cover.out
-
-integration-tests: install deploy server/deploy ## Run integration tests
-	kubectl apply -f testserver/build/clusters.open-cluster-management.io_managedclusters.yaml
-	kubectl wait --for=condition=available --timeout=60s deployment/discovery-operator -n $(NAMESPACE)
-	kubectl wait --for=condition=available --timeout=60s deployment/mock-ocm-server -n $(NAMESPACE)
-	go test -v ./test/e2e -coverprofile cover.out -args -ginkgo.v -ginkgo.trace -namespace $(NAMESPACE)
-
 ENCRYPTED = $(shell echo "ocmAPIToken: ${OCM_API_TOKEN}" | base64)
 secret: ## Generate secret for OCM access
-	cat config/samples/ocm-api-secret.yaml | sed -e "s/ENCRYPTED_TOKEN/$(ENCRYPTED)/g" | kubectl apply -f - || true
+	cat config/samples/ocm-api-secret.yaml | sed -e "s/ENCRYPTED_TOKEN/$(ENCRYPTED)/g" |  sed -e "s/NAMESPACE/$(NAMESPACE)/g" | kubectl apply -f - || true
 
-samples: ## Create custom resources
+.PHONY: config
+config: ## Create custom resources
+	cd config/samples && $(KUSTOMIZE) edit set namespace $(NAMESPACE)
 	$(KUSTOMIZE) build config/samples | kubectl apply -f -
+	cd config/samples && $(KUSTOMIZE) edit set namespace open-cluster-management
 
 logs: ## Print operator logs
 	@kubectl logs -f $(shell kubectl get pod -l app=discovery-operator -o jsonpath="{.items[0].metadata.name}")
@@ -116,7 +108,7 @@ unannotate: ## Remove mock server annotation
 set-copyright:
 	@bash ./cicd-scripts/set-copyright.sh
 
-verify: test integration-tests manifests
+verify: test deploy-and-test manifests
 
 ##@ Build
 
@@ -238,6 +230,38 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
+##@ Testing
+
+test: ## Run unit tests.
+	go test `go list ./... | grep -v e2e` -coverprofile cover.out
+
+integration-tests: ## Run functional/integration tests
+	kubectl apply -f testserver/build/clusters.open-cluster-management.io_managedclusters.yaml
+	go test -v ./test/e2e -coverprofile cover.out -args -ginkgo.v -ginkgo.trace -namespace $(NAMESPACE)
+
+integration-tests-local: ## Run functional tests with binaries running locally
+	kubectl create namespace $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	kubectl apply -f testserver/build/clusters.open-cluster-management.io_managedclusters.yaml
+	go test -v ./test/e2e -coverprofile cover.out -args -ginkgo.v -ginkgo.trace -namespace $(NAMESPACE) -baseURL http://localhost:3000
+
+deploy-and-test: install deploy server-deploy ## Install CRDs, deploy components, and run tests
+	kubectl apply -f testserver/build/clusters.open-cluster-management.io_managedclusters.yaml
+	kubectl wait --for=condition=available --timeout=60s deployment/discovery-operator -n $(NAMESPACE)
+	kubectl wait --for=condition=available --timeout=60s deployment/mock-ocm-server -n $(NAMESPACE)
+	sleep 10
+	go test -v ./test/e2e -coverprofile cover.out -args -ginkgo.v -ginkgo.trace -namespace $(NAMESPACE)
+
+docker-build-tests: ## Build the functional test image
+	@echo "Building $(REGISTRY)/$(IMG)-tests:$(VERSION)"
+	docker build . -f test/e2e/build/Dockerfile -t $(REGISTRY)/$(IMG)-tests:$(VERSION)
+
+docker-run-tests: ## Run the containerized functional tests
+	docker run --network host \
+		--volume ~/.kube/config:/opt/.kube/config \
+		$(REGISTRY)/$(IMG)-tests:$(VERSION)
+
+-include testserver/Makefile
+
 ############################################################
 # e2e test section
 ############################################################
@@ -275,18 +299,3 @@ kind-delete-cluster:
 kind-e2e-tests:
 	kubectl apply -f testserver/build/clusters.open-cluster-management.io_managedclusters.yaml
 	go test -v ./test/e2e -coverprofile cover.out -args -ginkgo.v -ginkgo.trace -namespace $(NAMESPACE)
-
-test-local:
-	kubectl apply -f testserver/build/clusters.open-cluster-management.io_managedclusters.yaml
-	go test -v ./test/e2e -coverprofile cover.out -args -ginkgo.v -ginkgo.trace -namespace $(NAMESPACE) -baseURL http://localhost:3000
-
-## Build the functional test image
-tests/docker-build:
-	@echo "Building $(REGISTRY)/$(IMG)-tests:$(VERSION)"
-	docker build . -f test/e2e/build/Dockerfile -t $(REGISTRY)/$(IMG)-tests:$(VERSION)
-
-## Run the downstream functional tests
-tests/docker-run:
-	docker run --network host \
-		--volume ~/.kube/config:/opt/.kube/config \
-		$(REGISTRY)/$(IMG)-tests:$(VERSION)

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
-## Append samples you want in your CSV to this file as resources ##
 resources:
-# - discovery_v1_discoveredcluster.yaml
 - discovery_v1_discoveryconfig.yaml
-# +kubebuilder:scaffold:manifestskustomizesamples
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: open-cluster-management

--- a/config/samples/ocm-api-secret.yaml
+++ b/config/samples/ocm-api-secret.yaml
@@ -9,5 +9,5 @@ metadata:
     cluster.open-cluster-management.io/cloudconnection: ""
     cluster.open-cluster-management.io/provider: crh
   name: ocm-api-token
-  namespace: open-cluster-management
+  namespace: NAMESPACE
 type: Opaque

--- a/testserver/Makefile
+++ b/testserver/Makefile
@@ -5,36 +5,32 @@
 SERVER_IMG := mock-ocm-server
 SERVER_URL ?= $(REGISTRY)/$(SERVER_IMG):$(VERSION)
 
-## Build Mock OCM Server Binary
-server/build:
+##@ Mock Server
+
+server-build: ## Build Mock OCM Server binary.
 	go build -o testserver/bin/local-server main.go
 
-## Start Mock OCM Server Binary
-server/run:
+server-run: ## Start Mock OCM Server binary.
 	cd testserver && go run main.go
 
-## Build Mock OCM Server Image
-server/docker-build:
+server-docker-build: ## Build Mock OCM Server Image.
 	docker build . -f ./testserver/build/Dockerfile -t "${SERVER_URL}"
 
-## Push Mock OCM Server Image
-server/docker-push:
+server-docker-push: ## Push Mock OCM Server Image.
 	docker push "${SERVER_URL}"
 
-## Run Mock OCM Server Image Locally
-server/docker-run:
+server-docker-run: ## Run Mock OCM Server Image Locally.
 	docker run -p 3000:3000 "${SERVER_URL}"
 
-## Annotate DiscoveryConfig with Mock OCM Server URL
-server/annotate:
-	oc annotate discoveryconfig discovery ocmBaseURL=http://mock-ocm-server.open-cluster-management.svc.cluster.local:3000 --overwrite
+server-annotate: ## Annotate DiscoveryConfig with Mock OCM Server URL.
+	oc annotate discoveryconfig discovery ocmBaseURL=http://mock-ocm-server.$(NAMESPACE).svc.cluster.local:3000 -n $(NAMESPACE) --overwrite
 
 DUMMY_ENCRYPTION = $(shell echo "ocmAPIToken: dummytoken" | base64)
-server/secret:
-	cat config/samples/ocm-api-secret.yaml | sed -e "s/ENCRYPTED_TOKEN/$(DUMMY_ENCRYPTION)/g" | kubectl apply -f - || true
+server-secret:
+	cat config/samples/ocm-api-secret.yaml | sed -e "s/ENCRYPTED_TOKEN/$(DUMMY_ENCRYPTION)/g" |  sed -e "s/NAMESPACE/$(NAMESPACE)/g" | kubectl apply -f - || true
 
 ## Build, push, and deploy server in cluster
-server/deploy:
+server-deploy:
 	@echo "Deploying with image ${SERVER_URL}"
 	cd testserver/build/local-server && $(KUSTOMIZE) edit set image testserver="${SERVER_URL}"
 	cd testserver/build/local-server && $(KUSTOMIZE) edit set namespace ${NAMESPACE}


### PR DESCRIPTION
Add info on running functional tests to the contributing doc. Update
the Makefile for the following improvements:

 - Add `testing` and `mock server` sections to `make help`

 - Update make targets with hardcoded namespace to use the NAMESPACE
   variable