### PR TITLE
Simplify format of token secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet `go list ./... | grep -v test`
 
-ENCRYPTED = $(shell echo "ocmAPIToken: ${OCM_API_TOKEN}" | base64)
+ENCRYPTED = $(shell echo "${OCM_API_TOKEN}" | base64)
 secret: ## Generate secret for OCM access
 	cat config/samples/ocm-api-secret.yaml | sed -e "s/ENCRYPTED_TOKEN/$(ENCRYPTED)/g" |  sed -e "s/NAMESPACE/$(NAMESPACE)/g" | kubectl apply -f - || true
 

--- a/config/samples/ocm-api-secret.yaml
+++ b/config/samples/ocm-api-secret.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: v1
 data:
-  metadata: ENCRYPTED_TOKEN
+  ocmAPIToken: ENCRYPTED_TOKEN
 kind: Secret
 metadata:
   labels:

--- a/controllers/discoveryconfig_controller.go
+++ b/controllers/discoveryconfig_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/open-cluster-management/discovery/util/reconciler"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -60,6 +61,11 @@ type DiscoveryConfigReconciler struct {
 	client.Client
 	Scheme  *runtime.Scheme
 	Trigger chan event.GenericEvent
+}
+
+// CloudRedHatCredential ...
+type CloudRedHatCredential struct {
+	OCMApiToken string `yaml:"ocmAPIToken"`
 }
 
 // +kubebuilder:rbac:groups=discovery.open-cluster-management.io,resources=discoveredclusters,verbs=get;list;watch;create;update;patch;delete;deletecollection
@@ -206,10 +212,25 @@ func (r *DiscoveryConfigReconciler) updateDiscoveredClusters(ctx context.Context
 func parseUserToken(secret *corev1.Secret) (string, error) {
 	token, ok := secret.Data["ocmAPIToken"]
 	if !ok {
-		return "", fmt.Errorf("%s: %w", secret.Name, ErrBadFormat)
+		return oldParseUserToken(secret)
+		// return "", fmt.Errorf("%s: %w", secret.Name, ErrBadFormat)
 	}
 
 	return strings.TrimSuffix(string(token), "\n"), nil
+}
+
+// old parsing function for backwards-compatibility
+func oldParseUserToken(secret *corev1.Secret) (string, error) {
+	if _, ok := secret.Data["metadata"]; !ok {
+		return "", fmt.Errorf("%s: %w", secret.Name, ErrBadFormat)
+	}
+
+	cred := &CloudRedHatCredential{}
+	if err := yaml.Unmarshal(secret.Data["metadata"], cred); err != nil {
+		return "", fmt.Errorf("%s: %w", secret.Name, ErrBadFormat)
+	}
+
+	return cred.OCMApiToken, nil
 }
 
 // assignManagedStatus marks clusters in the discovered map as managed if they are in the managed list

--- a/test/e2e/discoveryconfig_controller.go
+++ b/test/e2e/discoveryconfig_controller.go
@@ -635,7 +635,7 @@ func dummySecret() *corev1.Secret {
 			Namespace: discoveryNamespace,
 		},
 		StringData: map[string]string{
-			"metadata": "ocmAPIToken: dummytoken",
+			"ocmAPIToken": "dummytoken",
 		},
 	}
 }
@@ -647,7 +647,7 @@ func customSecret(name, namespace, token string) *corev1.Secret {
 			Namespace: namespace,
 		},
 		StringData: map[string]string{
-			"metadata": fmt.Sprintf("ocmAPIToken: %s", token),
+			"ocmAPIToken": token,
 		},
 	}
 }

--- a/testserver/Makefile
+++ b/testserver/Makefile
@@ -25,7 +25,7 @@ server-docker-run: ## Run Mock OCM Server Image Locally.
 server-annotate: ## Annotate DiscoveryConfig with Mock OCM Server URL.
 	oc annotate discoveryconfig discovery ocmBaseURL=http://mock-ocm-server.$(NAMESPACE).svc.cluster.local:3000 -n $(NAMESPACE) --overwrite
 
-DUMMY_ENCRYPTION = $(shell echo "ocmAPIToken: dummytoken" | base64)
+DUMMY_ENCRYPTION = $(shell echo "dummytoken" | base64)
 server-secret:
 	cat config/samples/ocm-api-secret.yaml | sed -e "s/ENCRYPTED_TOKEN/$(DUMMY_ENCRYPTION)/g" |  sed -e "s/NAMESPACE/$(NAMESPACE)/g" | kubectl apply -f - || true
 


### PR DESCRIPTION
Change data key-value format in secret holding creds.

OLD: 'metadata: "ocmAPIToken: \<TOKEN\>"'
NEW: 'ocmAPIToken: \<TOKEN\>'