### PR TITLE
Copyright header check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ catalog-push: ## Push a catalog image.
 
 ##@ Testing
 
+.PHONY: test
 test: ## Run unit tests.
 	go test `go list ./... | grep -v e2e` -coverprofile cover.out
 

--- a/cicd-scripts/build.sh
+++ b/cicd-scripts/build.sh
@@ -1,8 +1,0 @@
-# Copyright Contributors to the Open Cluster Management project
-
-#!/bin/bash
-# Copyright (c) 2020 Red Hat, Inc.
-
-echo "<repo>/<component>:<tag> : $1"
-
-docker build . -t $1

--- a/cicd-scripts/deploy-to-cluster.sh
+++ b/cicd-scripts/deploy-to-cluster.sh
@@ -1,5 +1,0 @@
-# Copyright Contributors to the Open Cluster Management project
-
-# Copyright (c) 2020 Red Hat, Inc.
-
-echo "DEPLOY TO CLUSTER GOES HERE! IT SHOULD DO NOTHING RIGHT NOW!"

--- a/cicd-scripts/e2e-test.sh
+++ b/cicd-scripts/e2e-test.sh
@@ -1,8 +1,0 @@
-# Copyright Contributors to the Open Cluster Management project
-
-#!/bin/bash
-# Copyright (c) 2020 Red Hat, Inc.
-
-echo "E2E TESTS GO HERE!"
-
-echo "<repo>/<component>:<tag> : $1"  

--- a/cicd-scripts/install-dependencies.sh
+++ b/cicd-scripts/install-dependencies.sh
@@ -1,6 +1,0 @@
-# Copyright Contributors to the Open Cluster Management project
-
-#!/bin/bash
-# Copyright (c) 2020 Red Hat, Inc.
-
-echo "INSTALL DEPENDENCIES GOES HERE!"

--- a/cicd-scripts/push.sh
+++ b/cicd-scripts/push.sh
@@ -1,8 +1,0 @@
-# Copyright Contributors to the Open Cluster Management project
-
-#!/bin/bash
-# Copyright (c) 2020 Red Hat, Inc.
-
-FULL_IMAGE_NAME=$1
-docker login "$FULL_IMAGE_NAME" -u "$DOCKER_USER" -p "$DOCKER_PASS"
-docker push  "$FULL_IMAGE_NAME"

--- a/cicd-scripts/unit-test.sh
+++ b/cicd-scripts/unit-test.sh
@@ -1,6 +1,0 @@
-# Copyright Contributors to the Open Cluster Management project
-
-#!/bin/bash
-# Copyright (c) 2020 Red Hat, Inc.
-
-go test -v ./pkg/...

--- a/licensetest/license_test.go
+++ b/licensetest/license_test.go
@@ -1,6 +1,6 @@
 // Copyright Contributors to the Open Cluster Management project
 
-// Package license scans the repo for missing license or copyright headers
+// Package licensetest scans the repo for missing copyright headers
 package licensetest
 
 import (

--- a/licensetest/license_test.go
+++ b/licensetest/license_test.go
@@ -1,0 +1,65 @@
+// Copyright Contributors to the Open Cluster Management project
+
+// Package license scans the repo for missing license or copyright headers
+package licensetest
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// slashScanner is for validating the copyright comment in Go files
+var slashScanner = regexp.MustCompile(`// Copyright Contributors to the Open Cluster Management project`)
+
+// poundScanner is for validating the copyright comment in shell and Python files
+var poundScanner = regexp.MustCompile(`\# Copyright Contributors to the Open Cluster Management project`)
+
+var skip = map[string]bool{
+	"../api/v1alpha1/zz_generated.deepcopy.go": true, // Generated file
+}
+
+func TestLicense(t *testing.T) {
+	err := filepath.Walk("..", func(path string, info os.FileInfo, err error) error {
+		if skip[path] {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		// Capture Go code, Python code, and shell scripts
+		if filepath.Ext(path) != ".go" && filepath.Ext(path) != ".sh" && filepath.Ext(path) != ".py" {
+			return nil
+		}
+
+		src, err := ioutil.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+
+		// Find license
+		if filepath.Ext(path) == ".go" {
+			if !slashScanner.Match(src) {
+				t.Errorf("%v: license header not present", path)
+				return nil
+			}
+		} else {
+			if !poundScanner.Match(src) {
+				t.Errorf("%v: license header not present", path)
+				return nil
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package ocm
 
 import (

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package ocm
 
 import (

--- a/pkg/ocm/subscription/domain.go
+++ b/pkg/ocm/subscription/domain.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package subscription
 
 import (

--- a/pkg/ocm/subscription/filters.go
+++ b/pkg/ocm/subscription/filters.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package subscription
 
 import (

--- a/pkg/ocm/subscription/filters_test.go
+++ b/pkg/ocm/subscription/filters_test.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package subscription
 
 import (

--- a/pkg/ocm/subscription/provider.go
+++ b/pkg/ocm/subscription/provider.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package subscription
 
 import (

--- a/pkg/ocm/subscription/provider_test.go
+++ b/pkg/ocm/subscription/provider_test.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package subscription
 
 import (

--- a/pkg/ocm/subscription/service.go
+++ b/pkg/ocm/subscription/service.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package subscription
 
 import (

--- a/pkg/ocm/subscription/service_test.go
+++ b/pkg/ocm/subscription/service_test.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package subscription
 
 import (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package e2e
 
 import (

--- a/testserver/api/auth.go
+++ b/testserver/api/auth.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package api
 
 import (

--- a/testserver/api/endpoints.go
+++ b/testserver/api/endpoints.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package api
 
 import (

--- a/testserver/api/scenario.go
+++ b/testserver/api/scenario.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package api
 
 import (

--- a/testserver/api/subscriptions.go
+++ b/testserver/api/subscriptions.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package api
 
 import (

--- a/testserver/generate-scripts/generatemanagedclusters/generate.go
+++ b/testserver/generate-scripts/generatemanagedclusters/generate.go
@@ -1,3 +1,5 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package main
 
 import (


### PR DESCRIPTION
Introduces a check for copyright headers introduced in https://github.com/open-cluster-management/discovery/pull/25 and adds the header to new files created since then.